### PR TITLE
Capture double/single-quoted atoms used as keys in keyword lists or maps

### DIFF
--- a/grammars/elixir.cson
+++ b/grammars/elixir.cson
@@ -1358,6 +1358,45 @@
     ]
   }
   {
+    'comment': """
+      symbols with single-quoted string, used as keys in Keyword lists.
+
+      In this case, `:` is suffixed to single-quoted string.
+      Leading letter `'` is exactly the same as in ordinary single-quoted string,
+      so this pattern is slightly difficult to capture.
+
+      In order to warn unescaped single-quotes inside matched string,
+      it treats them separately with `.invalid.illegal` scopes.
+
+      It warns you for patterns such as `'foo'bar':`, while not for `'foo\'bar':`.
+    """
+    'match': '(\')(.*)(\':)(?!:)'
+    'name': 'constant.other.symbol.single-quoted.elixir'
+    'captures': {
+      '1':
+        'name': 'punctuation.definition.constant.elixir'
+      '2':
+        'patterns': [
+          {
+            'match': '\\\\\''
+            'name': 'constant.character.escape.elixir'
+          }
+          {
+            'match': '\''
+            'name': 'invalid.illegal.unescaped.single-quote.elixir'
+          }
+          {
+            'include': '#interpolated_elixir'
+          }
+          {
+            'include': '#escaped_char'
+          }
+        ]
+      '3':
+        'name': 'punctuation.definition.constant.elixir'
+    }
+  }
+  {
     'begin': ':"'
     'captures':
       '0':
@@ -1432,6 +1471,39 @@
         'include': '#escaped_char'
       }
     ]
+  }
+  {
+    'comment': """
+      symbols defined by double-quoted string, used as keys in Keyword lists.
+
+      Treats double-quotes inside matched string separately
+      as in the case of symbols defined by single-quoted string.
+    """
+    'match': '(")(.*)(":)(?!:)'
+    'name': 'constant.other.symbol.double-quoted.elixir'
+    'captures': {
+      '1':
+        'name': 'punctuation.definition.constant.elixir'
+      '2':
+        'patterns': [
+          {
+            'match': '\\\\"'
+            'name': 'constant.character.escape.elixir'
+          }
+          {
+            'match': '"'
+            'name': 'invalid.illegal.unescaped.double-quote.elixir'
+          }
+          {
+            'include': '#interpolated_elixir'
+          }
+          {
+            'include': '#escaped_char'
+          }
+        ]
+      '3':
+        'name': 'punctuation.definition.constant.elixir'
+    }
   }
   {
     'begin': '"'

--- a/grammars/elixir.cson
+++ b/grammars/elixir.cson
@@ -1365,26 +1365,17 @@
       Leading letter `'` is exactly the same as in ordinary single-quoted string,
       so this pattern is slightly difficult to capture.
 
-      In order to warn unescaped single-quotes inside matched string,
-      it treats them separately with `.invalid.illegal` scopes.
-
-      It warns you for patterns such as `'foo'bar':`, while not for `'foo\'bar':`.
+      This pattern only matches symbols when they do not have line breaks OR
+      (escaped or unescaped) single-quotes inside outermost single-quotes.
+      Thus, it will not match for patterns like `'foo\'bar':`.
     """
-    'match': '(\')(.*)(\':)(?!:)'
+    'match': '(\')([^\']*)(\':)(?!:)'
     'name': 'constant.other.symbol.single-quoted.elixir'
     'captures': {
       '1':
         'name': 'punctuation.definition.constant.elixir'
       '2':
         'patterns': [
-          {
-            'match': '\\\\\''
-            'name': 'constant.character.escape.elixir'
-          }
-          {
-            'match': '\''
-            'name': 'invalid.illegal.unescaped.single-quote.elixir'
-          }
           {
             'include': '#interpolated_elixir'
           }
@@ -1473,27 +1464,14 @@
     ]
   }
   {
-    'comment': """
-      symbols defined by double-quoted string, used as keys in Keyword lists.
-
-      Treats double-quotes inside matched string separately
-      as in the case of symbols defined by single-quoted string.
-    """
-    'match': '(")(.*)(":)(?!:)'
+    'comment': 'symbols defined by double-quoted string, used as keys in Keyword lists.'
+    'match': '(")([^"]*)(":)(?!:)'
     'name': 'constant.other.symbol.double-quoted.elixir'
     'captures': {
       '1':
         'name': 'punctuation.definition.constant.elixir'
       '2':
         'patterns': [
-          {
-            'match': '\\\\"'
-            'name': 'constant.character.escape.elixir'
-          }
-          {
-            'match': '"'
-            'name': 'invalid.illegal.unescaped.double-quote.elixir'
-          }
           {
             'include': '#interpolated_elixir'
           }

--- a/spec/elixir-spec.coffee
+++ b/spec/elixir-spec.coffee
@@ -152,6 +152,34 @@ describe "Elixir grammar", ->
     expect(tokens[0]).toEqual value: 'case', scopes: ['source.elixir', 'constant.other.symbol.elixir']
     expect(tokens[1]).toEqual value: ':', scopes: ['source.elixir', 'constant.other.symbol.elixir', 'punctuation.definition.constant.elixir']
 
+    {tokens} = grammar.tokenizeLine(':"symbol"')
+    expect(tokens[0]).toEqual value: ':"', scopes: ['source.elixir', 'constant.other.symbol.double-quoted.elixir', 'punctuation.definition.constant.elixir']
+    expect(tokens[1]).toEqual value: 'symbol', scopes: ['source.elixir', 'constant.other.symbol.double-quoted.elixir']
+    expect(tokens[2]).toEqual value: '"', scopes: ['source.elixir', 'constant.other.symbol.double-quoted.elixir', 'punctuation.definition.constant.elixir']
+
+    {tokens} = grammar.tokenizeLine('"symbol as key":')
+    expect(tokens[0]).toEqual value: '"', scopes: ['source.elixir', 'constant.other.symbol.double-quoted.elixir', 'punctuation.definition.constant.elixir']
+    expect(tokens[1]).toEqual value: 'symbol as key', scopes: ['source.elixir', 'constant.other.symbol.double-quoted.elixir']
+    expect(tokens[2]).toEqual value: '":', scopes: ['source.elixir', 'constant.other.symbol.double-quoted.elixir', 'punctuation.definition.constant.elixir']
+
+    {tokens} = grammar.tokenizeLine('"symbol as key with unescaped " inside":')
+    expect(tokens[0]).toEqual value: '"', scopes: ['source.elixir', 'constant.other.symbol.double-quoted.elixir', 'punctuation.definition.constant.elixir']
+    expect(tokens[1]).toEqual value: 'symbol as key with unescaped ', scopes: ['source.elixir', 'constant.other.symbol.double-quoted.elixir']
+    expect(tokens[2]).toEqual value: '"', scopes: ['source.elixir', 'constant.other.symbol.double-quoted.elixir', 'invalid.illegal.unescaped.double-quote.elixir']
+    expect(tokens[3]).toEqual value: ' inside', scopes: ['source.elixir', 'constant.other.symbol.double-quoted.elixir']
+    expect(tokens[4]).toEqual value: '":', scopes: ['source.elixir', 'constant.other.symbol.double-quoted.elixir', 'punctuation.definition.constant.elixir']
+
+    {tokens} = grammar.tokenizeLine('"symbol as key with escaped \\" inside":')
+    expect(tokens[2]).toEqual value: '\\"', scopes: ['source.elixir', 'constant.other.symbol.double-quoted.elixir', 'constant.character.escape.elixir']
+
+    {tokens} = grammar.tokenizeLine('"symbol as key with improperly-escaped \\\\" inside":')
+    expect(tokens[2]).toEqual value: '\\\\', scopes: ['source.elixir', 'constant.other.symbol.double-quoted.elixir', 'constant.character.escape.elixir']
+    expect(tokens[3]).toEqual value: '"', scopes: ['source.elixir', 'constant.other.symbol.double-quoted.elixir', 'invalid.illegal.unescaped.double-quote.elixir']
+
+    {tokens} = grammar.tokenizeLine('"symbol as key with hard-to-see-but-properly-escaped \\\\\\" inside":')
+    expect(tokens[2]).toEqual value: '\\\\', scopes: ['source.elixir', 'constant.other.symbol.double-quoted.elixir', 'constant.character.escape.elixir']
+    expect(tokens[3]).toEqual value: '\\"', scopes: ['source.elixir', 'constant.other.symbol.double-quoted.elixir', 'constant.character.escape.elixir']
+
   it "tokenizes comments", ->
     {tokens} = grammar.tokenizeLine("# TODO: stuff")
     expect(tokens[0]).toEqual value: '#', scopes: ['source.elixir', 'comment.line.number-sign.elixir', 'punctuation.definition.comment.elixir']

--- a/spec/elixir-spec.coffee
+++ b/spec/elixir-spec.coffee
@@ -163,22 +163,18 @@ describe "Elixir grammar", ->
     expect(tokens[2]).toEqual value: '":', scopes: ['source.elixir', 'constant.other.symbol.double-quoted.elixir', 'punctuation.definition.constant.elixir']
 
     {tokens} = grammar.tokenizeLine('"symbol as key with unescaped " inside":')
-    expect(tokens[0]).toEqual value: '"', scopes: ['source.elixir', 'constant.other.symbol.double-quoted.elixir', 'punctuation.definition.constant.elixir']
-    expect(tokens[1]).toEqual value: 'symbol as key with unescaped ', scopes: ['source.elixir', 'constant.other.symbol.double-quoted.elixir']
-    expect(tokens[2]).toEqual value: '"', scopes: ['source.elixir', 'constant.other.symbol.double-quoted.elixir', 'invalid.illegal.unescaped.double-quote.elixir']
-    expect(tokens[3]).toEqual value: ' inside', scopes: ['source.elixir', 'constant.other.symbol.double-quoted.elixir']
-    expect(tokens[4]).toEqual value: '":', scopes: ['source.elixir', 'constant.other.symbol.double-quoted.elixir', 'punctuation.definition.constant.elixir']
+    expect(tokens[0]).toEqual value: '"', scopes: ['source.elixir', 'string.quoted.double.elixir', 'punctuation.definition.string.begin.elixir']
+    expect(tokens[1]).toEqual value: 'symbol as key with unescaped ', scopes: ['source.elixir', 'string.quoted.double.elixir']
+    expect(tokens[2]).toEqual value: '"', scopes: ['source.elixir', 'string.quoted.double.elixir', 'punctuation.definition.string.end.elixir']
+    expect(tokens[3]).toEqual value: ' inside', scopes: ['source.elixir']
+    expect(tokens[4]).toEqual value: '"', scopes: ['source.elixir', 'string.quoted.double.elixir', 'punctuation.definition.string.begin.elixir']
+    expect(tokens[5]).toEqual value: ':', scopes: ['source.elixir', 'string.quoted.double.elixir']
 
     {tokens} = grammar.tokenizeLine('"symbol as key with escaped \\" inside":')
-    expect(tokens[2]).toEqual value: '\\"', scopes: ['source.elixir', 'constant.other.symbol.double-quoted.elixir', 'constant.character.escape.elixir']
-
-    {tokens} = grammar.tokenizeLine('"symbol as key with improperly-escaped \\\\" inside":')
-    expect(tokens[2]).toEqual value: '\\\\', scopes: ['source.elixir', 'constant.other.symbol.double-quoted.elixir', 'constant.character.escape.elixir']
-    expect(tokens[3]).toEqual value: '"', scopes: ['source.elixir', 'constant.other.symbol.double-quoted.elixir', 'invalid.illegal.unescaped.double-quote.elixir']
-
-    {tokens} = grammar.tokenizeLine('"symbol as key with hard-to-see-but-properly-escaped \\\\\\" inside":')
-    expect(tokens[2]).toEqual value: '\\\\', scopes: ['source.elixir', 'constant.other.symbol.double-quoted.elixir', 'constant.character.escape.elixir']
-    expect(tokens[3]).toEqual value: '\\"', scopes: ['source.elixir', 'constant.other.symbol.double-quoted.elixir', 'constant.character.escape.elixir']
+    expect(tokens[2]).toEqual value: '\\"', scopes: ['source.elixir', 'string.quoted.double.elixir', 'constant.character.escape.elixir']
+    expect(tokens[3]).toEqual value: ' inside', scopes: ['source.elixir', 'string.quoted.double.elixir']
+    expect(tokens[4]).toEqual value: '"', scopes: ['source.elixir', 'string.quoted.double.elixir', 'punctuation.definition.string.end.elixir']
+    expect(tokens[5]).toEqual value: ':', scopes: ['source.elixir', 'punctuation.separator.other.elixir']
 
   it "tokenizes comments", ->
     {tokens} = grammar.tokenizeLine("# TODO: stuff")


### PR DESCRIPTION
Atoms can be defined using double/single-quotes, with arbitrary unicode (with erlang 20.x onwards; otherwise ascii? or Latin-1? I don't recall) strings.
When used as keys in keyword lists or maps, they can also be written in short-hand style.
```ex
Interactive Elixir (1.5.1) - press Ctrl+C to exit (type h() ENTER for help)
iex(1)> :"foo bar"
:"foo bar"
iex(2)> ["foo bar": :baz]
["foo bar": :baz]
```

This PR introduces highlight support for latter; **double/single-quoted atoms used as keys** where colons are suffixed to strings.

Edit: Initially I proposed and introduced an idea to match all letters inside quotes, then warn for unescaped quotes inside.
Though it turned out it won't work well when there are multiple valid matches within a single line. So I scrapped that in 3ed4064

Current behavior (with One Dark theme):
![2017-08-09 15 49 47](https://user-images.githubusercontent.com/4507126/29108592-a2740c5c-7d1a-11e7-88a5-60a0e2f5836f.png)

With this PR:
![2017-08-14 17 53 54](https://user-images.githubusercontent.com/4507126/29264895-d405139e-8119-11e7-945b-704616954908.png)

As shown in the above, the introduced patterns will not match when there are nested single/double-quotes inside, even if they are properly escaped.
This is caused by the difficulty to capture such patterns, since starting letter of these patterns are identical to ordinary strings (thus we cannot use `begin`-`end` section). 

As a reference, in case of normal double/single-quoted atoms:
![2017-08-09 15 50 32](https://user-images.githubusercontent.com/4507126/29108629-c9b2af12-7d1a-11e7-963d-41c762e59adc.png)

---
As a note, I have found atoms are referred to as 'symbols' in the file (residue from Ruby package?).
Could use renaming, though I kept using 'symbols' in my hunks for consistency.