### PR TITLE
Add "and", "or", and "not" to the list of highlighted keywords

### DIFF
--- a/grammars/elixir.cson
+++ b/grammars/elixir.cson
@@ -110,7 +110,7 @@
     'name': 'constant.other.symbol.elixir'
   }
   {
-    'match': '(?<!\\.)\\b(do|end|case|bc|lc|for|if|cond|with|unless|try|receive|fn|defmodule|defprotocol|defimpl|defrecordp?|defstruct|defdelegate|defcallback|defexception|defoverridable|exit|after|rescue|catch|else|raise|throw|quote|unquote|super|when)\\b(?![?!])'
+    'match': '(?<!\\.)\\b(do|end|case|bc|lc|for|if|cond|with|unless|try|receive|fn|defmodule|defprotocol|defimpl|defrecordp?|defstruct|defdelegate|defcallback|defexception|defoverridable|exit|after|rescue|catch|else|raise|throw|quote|unquote|super|when|and|or|not)\\b(?![?!])'
     'name': 'keyword.control.elixir'
   }
   {


### PR DESCRIPTION
This pull request adds the words "and", "or", and "not" to the list of highlight keywords.