### PR TITLE
Add "in" to the list of highlighted keywords

### DIFF
--- a/grammars/elixir.cson
+++ b/grammars/elixir.cson
@@ -110,7 +110,7 @@
     'name': 'constant.other.symbol.elixir'
   }
   {
-    'match': '(?<!\\.)\\b(do|end|case|bc|lc|for|if|cond|with|unless|try|receive|fn|defmodule|defprotocol|defimpl|defrecordp?|defstruct|defdelegate|defcallback|defexception|defoverridable|exit|after|rescue|catch|else|raise|throw|quote|unquote|super|when|and|or|not)\\b(?![?!])'
+    'match': '(?<!\\.)\\b(do|end|case|bc|lc|for|if|cond|with|unless|try|receive|fn|defmodule|defprotocol|defimpl|defrecordp?|defstruct|defdelegate|defcallback|defexception|defoverridable|exit|after|rescue|catch|else|raise|throw|quote|unquote|super|when|and|or|not|in)\\b(?![?!])'
     'name': 'keyword.control.elixir'
   }
   {


### PR DESCRIPTION
This pull request adds the words "in" to the list of highlight keywords. 

I somehow missed this one yesterday. :)