### PR TITLE
Handle escaped characters inside string and charlist atoms

### DIFF
--- a/grammars/elixir.cson
+++ b/grammars/elixir.cson
@@ -1360,16 +1360,8 @@
   {
     'comment': """
       symbols with single-quoted string, used as keys in Keyword lists.
-
-      In this case, `:` is suffixed to single-quoted string.
-      Leading letter `'` is exactly the same as in ordinary single-quoted string,
-      so this pattern is slightly difficult to capture.
-
-      This pattern only matches symbols when they do not have line breaks OR
-      (escaped or unescaped) single-quotes inside outermost single-quotes.
-      Thus, it will not match for patterns like `'foo\'bar':`.
     """
-    'match': '(\')([^\']*)(\':)(?!:)'
+    'match': "(')((?:[^'\\\\]*(?:\\\\.[^'\\\\]*)*))(':)(?!:)"
     'name': 'constant.other.symbol.single-quoted.elixir'
     'captures': {
       '1':
@@ -1465,7 +1457,7 @@
   }
   {
     'comment': 'symbols defined by double-quoted string, used as keys in Keyword lists.'
-    'match': '(")([^"]*)(":)(?!:)'
+    'match': '(")((?:[^"\\\\]*(?:\\\\.[^"\\\\]*)*))(":)(?!:)'
     'name': 'constant.other.symbol.double-quoted.elixir'
     'captures': {
       '1':

--- a/spec/elixir-spec.coffee
+++ b/spec/elixir-spec.coffee
@@ -171,10 +171,22 @@ describe "Elixir grammar", ->
     expect(tokens[5]).toEqual value: ':', scopes: ['source.elixir', 'string.quoted.double.elixir']
 
     {tokens} = grammar.tokenizeLine('"symbol as key with escaped \\" inside":')
-    expect(tokens[2]).toEqual value: '\\"', scopes: ['source.elixir', 'string.quoted.double.elixir', 'constant.character.escape.elixir']
-    expect(tokens[3]).toEqual value: ' inside', scopes: ['source.elixir', 'string.quoted.double.elixir']
-    expect(tokens[4]).toEqual value: '"', scopes: ['source.elixir', 'string.quoted.double.elixir', 'punctuation.definition.string.end.elixir']
-    expect(tokens[5]).toEqual value: ':', scopes: ['source.elixir', 'punctuation.separator.other.elixir']
+    expect(tokens[1]).toEqual value: 'symbol as key with escaped ', scopes: ['source.elixir', 'constant.other.symbol.double-quoted.elixir']
+    expect(tokens[2]).toEqual value: '\\"', scopes: ['source.elixir', 'constant.other.symbol.double-quoted.elixir', 'constant.character.escape.elixir']
+    expect(tokens[3]).toEqual value: ' inside', scopes: ['source.elixir', 'constant.other.symbol.double-quoted.elixir']
+    expect(tokens[4]).toEqual value: '":', scopes: ['source.elixir', 'constant.other.symbol.double-quoted.elixir', 'punctuation.definition.constant.elixir']
+
+    {tokens} = grammar.tokenizeLine("'charlist as key':")
+    expect(tokens[0]).toEqual value: "'", scopes: ['source.elixir', 'constant.other.symbol.single-quoted.elixir', 'punctuation.definition.constant.elixir']
+    expect(tokens[1]).toEqual value: 'charlist as key', scopes: ['source.elixir', 'constant.other.symbol.single-quoted.elixir']
+    expect(tokens[2]).toEqual value: "':", scopes: ['source.elixir', 'constant.other.symbol.single-quoted.elixir', 'punctuation.definition.constant.elixir']
+
+    {tokens} = grammar.tokenizeLine("'charlist as key with escaped \\' inside':")
+    expect(tokens[0]).toEqual value: "'", scopes: ['source.elixir', 'constant.other.symbol.single-quoted.elixir', 'punctuation.definition.constant.elixir']
+    expect(tokens[1]).toEqual value: 'charlist as key with escaped ', scopes: ['source.elixir', 'constant.other.symbol.single-quoted.elixir']
+    expect(tokens[2]).toEqual value: "\\'", scopes: ['source.elixir', 'constant.other.symbol.single-quoted.elixir', 'constant.character.escape.elixir']
+    expect(tokens[3]).toEqual value: " inside", scopes: ['source.elixir', 'constant.other.symbol.single-quoted.elixir']
+    expect(tokens[4]).toEqual value: "':", scopes: ['source.elixir', 'constant.other.symbol.single-quoted.elixir', 'punctuation.definition.constant.elixir']
 
   it "tokenizes comments", ->
     {tokens} = grammar.tokenizeLine("# TODO: stuff")


### PR DESCRIPTION
This pull request fixes an issue introduced in a0824b9 that caused syntax highlighting to break on certain strings and charlists. Specifically, strings containing an escaped double quote followed by a semicolon ```"\": "``` and charlists containing an escaped single quote followed by a semicolon ```'\': '```.

![single_broken](https://user-images.githubusercontent.com/37242/30007189-e508a1d2-90ce-11e7-9096-5bdd9673f290.jpg)
![double_broken](https://user-images.githubusercontent.com/37242/30007191-e6a076fa-90ce-11e7-9a83-cc791d9904a2.jpg)

The files now render as:

![single_fixed](https://user-images.githubusercontent.com/37242/30007204-113b6d20-90cf-11e7-9e77-f44932ca9844.jpg)
![double_fixed](https://user-images.githubusercontent.com/37242/30007206-1266f840-90cf-11e7-957b-fa777b2c7a0e.jpg)
