### PR TITLE
Add snippets for custom guards added in Elixir 1.6

### DIFF
--- a/snippets/language-elixir.cson
+++ b/snippets/language-elixir.cson
@@ -14,6 +14,12 @@
   'defp':
     'prefix': 'defp'
     'body': 'defp ${1:function_name} do\n\t$0\nend'
+   'defguard':
+    'prefix': 'defguard'
+    'body': 'defguard ${1:guard_name}($2) when $3'
+  'defguardp':
+    'prefix': 'defguardp'
+    'body': 'defguardp ${1:guard_name}($2) when $3'
   'defmacro':
     'prefix': 'defmacro'
     'body': 'defmacro ${1:macro_name} do\n\t$0\nend'


### PR DESCRIPTION
Ability to generate [custom guards](https://hexdocs.pm/elixir/Kernel.html#defguard/1) was added in Elixir 1.6.  
These changes are adding snippets for `gefguard` and `defguardp`.