### PR TITLE
Expand doc snippets correctly

### DIFF
--- a/snippets/language-elixir.cson
+++ b/snippets/language-elixir.cson
@@ -34,7 +34,7 @@
     'body': 'defstruct [$1]'
   'doc':
     'prefix': 'doc'
-    'body': '@doc """$0\n"""'
+    'body': '@doc """\n$0\n"""'
   'do':
     'prefix': 'do'
     'body': 'do\n\t$0\nend'
@@ -55,7 +55,7 @@
     'body': 'defp $1, do: $2'
   'moduledoc':
     'prefix': 'moduledoc'
-    'body': '@moduledoc """$0\n"""'
+    'body': '@moduledoc """\n$0\n"""'
   'moduletag':
     'prefix': 'moduletag'
     'body': '@moduletag ${1::${2:your_tag}}'
@@ -118,7 +118,7 @@
     'body': '@type ${1:type_name} :: ${2:type}'
   'typedoc':
     'prefix': 'typedoc'
-    'body': '@typedoc """$0\n"""'
+    'body': '@typedoc """\n$0\n"""'
   'fn':
     'prefix': 'fn'
     'body': 'fn($1) -> ${2:...} end'


### PR DESCRIPTION
We weren't able to expand snippets correctly before due to a bug upstream in the snippet library and in atom. Those issues have all been fixed so now we can automatically expand snippets in a much more convenient way.

![atom_example](https://user-images.githubusercontent.com/1642095/35886536-58d8df04-0b5f-11e8-89f6-4b77972cb8bb.gif)
