### PR TITLE
Issue 83: Prevent "#{}" expansion in literal heredocs

### DIFF
--- a/grammars/elixir.cson
+++ b/grammars/elixir.cson
@@ -53,7 +53,7 @@
     'begin': '@(module|type)?doc ~S"""'
     'comment': '@doc with heredocs is treated as documentation'
     'end': '\\s*"""'
-    'name': 'comment.documentation.heredoc.elixir'
+    'name': 'comment.documentation.heredoc.literal.elixir'
     'patterns': [
       {
         'include': '#escaped_char'
@@ -64,7 +64,7 @@
     'begin': "@(module|type)?doc ~S'''"
     'comment': '@doc with heredocs is treated as documentation'
     'end': "\\s*'''"
-    'name': 'comment.documentation.heredoc.elixir'
+    'name': 'comment.documentation.heredoc.literal.elixir'
     'patterns': [
       {
         'include': '#escaped_char'

--- a/spec/elixir-spec.coffee
+++ b/spec/elixir-spec.coffee
@@ -633,14 +633,14 @@ describe "Elixir grammar", ->
       expect(tokens[2]).toEqual value: '\n"""', scopes: ['source.elixir', 'comment.documentation.heredoc.elixir']
 
       {tokens} = grammar.tokenizeLine('@doc ~S"""\nTest\n"""')
-      expect(tokens[0]).toEqual value: '@doc ~S"""', scopes: ['source.elixir', 'comment.documentation.heredoc.elixir']
-      expect(tokens[1]).toEqual value: '\nTest', scopes: ['source.elixir', 'comment.documentation.heredoc.elixir']
-      expect(tokens[2]).toEqual value: '\n"""', scopes: ['source.elixir', 'comment.documentation.heredoc.elixir']
+      expect(tokens[0]).toEqual value: '@doc ~S"""', scopes: ['source.elixir', 'comment.documentation.heredoc.literal.elixir']
+      expect(tokens[1]).toEqual value: '\nTest', scopes: ['source.elixir', 'comment.documentation.heredoc.literal.elixir']
+      expect(tokens[2]).toEqual value: '\n"""', scopes: ['source.elixir', 'comment.documentation.heredoc.literal.elixir']
 
       {tokens} = grammar.tokenizeLine("@doc ~S'''\nTest\n'''")
-      expect(tokens[0]).toEqual value: "@doc ~S'''", scopes: ['source.elixir', 'comment.documentation.heredoc.elixir']
-      expect(tokens[1]).toEqual value: '\nTest', scopes: ['source.elixir', 'comment.documentation.heredoc.elixir']
-      expect(tokens[2]).toEqual value: "\n'''", scopes: ['source.elixir', 'comment.documentation.heredoc.elixir']
+      expect(tokens[0]).toEqual value: "@doc ~S'''", scopes: ['source.elixir', 'comment.documentation.heredoc.literal.elixir']
+      expect(tokens[1]).toEqual value: '\nTest', scopes: ['source.elixir', 'comment.documentation.heredoc.literal.elixir']
+      expect(tokens[2]).toEqual value: "\n'''", scopes: ['source.elixir', 'comment.documentation.heredoc.literal.elixir']
 
     it "does not highlight other sigil heredocs as comments", ->
       {tokens} = grammar.tokenizeLine("@doc '''\nTest\n'''")
@@ -650,19 +650,19 @@ describe "Elixir grammar", ->
       expect(tokens[0]).not.toEqual value: '@doc ~r"""', scopes: ['source.elixir', 'comment.documentation.heredoc.elixir']
 
       {tokens} = grammar.tokenizeLine('@doc ~R"""\nTest\n"""')
-      expect(tokens[0]).not.toEqual value: '@doc ~R"""', scopes: ['source.elixir', 'comment.documentation.heredoc.elixir']
+      expect(tokens[0]).not.toEqual value: '@doc ~R"""', scopes: ['source.elixir', 'comment.documentation.heredoc.literal.elixir']
 
       {tokens} = grammar.tokenizeLine('@doc ~c"""\nTest\n"""')
       expect(tokens[0]).not.toEqual value: '@doc ~c"""', scopes: ['source.elixir', 'comment.documentation.heredoc.elixir']
 
       {tokens} = grammar.tokenizeLine('@doc ~C"""\nTest\n"""')
-      expect(tokens[0]).not.toEqual value: '@doc ~C"""', scopes: ['source.elixir', 'comment.documentation.heredoc.elixir']
+      expect(tokens[0]).not.toEqual value: '@doc ~C"""', scopes: ['source.elixir', 'comment.documentation.heredoc.literal.elixir']
 
       {tokens} = grammar.tokenizeLine('@doc ~w"""\nTest\n"""')
       expect(tokens[0]).not.toEqual value: '@doc ~w"""', scopes: ['source.elixir', 'comment.documentation.heredoc.elixir']
 
       {tokens} = grammar.tokenizeLine('@doc ~W"""\nTest\n"""')
-      expect(tokens[0]).not.toEqual value: '@doc ~W"""', scopes: ['source.elixir', 'comment.documentation.heredoc.elixir']
+      expect(tokens[0]).not.toEqual value: '@doc ~W"""', scopes: ['source.elixir', 'comment.documentation.heredoc.literal.elixir']
 
   describe "functions", ->
     it "tokenizes single line functions without parameters", ->


### PR DESCRIPTION
The [atom-brackets package](https://github.com/atom/bracket-matcher/blob/master/lib/bracket-matcher.coffee#L194) is configured to expand "#" into "#{$1}" in `comment.documentation.heredoc.elixir` contexts. To avoid this and close #83, this changes literal heredoc contexts (`~S`) to have a more specific tag, `comment.documentation.heredoc.literal.elixir`.

Tested by `apm link`ing the modified `language-elixir` locally and confirmed that "#" no longer expanded in literal heredocs.  Also modified existing tests to expect the new name where appropriate.