### PR TITLE
Issue 106: Add ExUnit "test" and "describe" macros to grammar

### DIFF
--- a/grammars/elixir.cson
+++ b/grammars/elixir.cson
@@ -110,7 +110,7 @@
     'name': 'constant.other.symbol.elixir'
   }
   {
-    'match': '(?<!\\.)\\b(do|end|case|bc|lc|for|if|cond|with|unless|try|receive|fn|defmodule|defprotocol|defimpl|defrecordp?|defstruct|defdelegate|defcallback|defexception|defoverridable|defguardp?|exit|after|rescue|catch|else|raise|throw|quote|unquote|super|when|and|or|not|in)\\b(?![?!])'
+    'match': '(?<!\\.)\\b(do|end|case|bc|lc|for|if|cond|with|unless|try|receive|fn|defmodule|defprotocol|defimpl|defrecordp?|defstruct|defdelegate|defcallback|defexception|defoverridable|defguardp?|exit|after|rescue|catch|else|raise|throw|quote|unquote|super|when|and|or|not|in|describe|test)\\b(?![?!])'
     'name': 'keyword.control.elixir'
   }
   {

--- a/spec/elixir-spec.coffee
+++ b/spec/elixir-spec.coffee
@@ -467,6 +467,13 @@ describe "Elixir grammar", ->
     expect(tokens[1]).toEqual value: 'test #{foo}', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir']
     expect(tokens[2]).toEqual value: '\'\'\'', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'punctuation.definition.string.end.elixir']
 
+  it "tokenizes ExUnit macros", ->
+    {tokens} = grammar.tokenizeLine("describe 'some description' do")
+    expect(tokens[0]).toEqual value: 'describe', scopes: ['source.elixir', 'keyword.control.elixir']
+
+    {tokens} = grammar.tokenizeLine("test 'some assertion' do")
+    expect(tokens[0]).toEqual value: 'test', scopes: ['source.elixir', 'keyword.control.elixir']
+
   describe "word lists", ->
     it "tokenizes interpolated word lists", ->
       {tokens} = grammar.tokenizeLine('~w"#{foo} bar"')


### PR DESCRIPTION
Add ExUnit 'test' and 'describe' macros to grammar to support highlighting. Addresses [#106](https://github.com/elixir-editors/language-elixir/issues/106).